### PR TITLE
Fix Fabric mod json warnings

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -1,5 +1,4 @@
 {
-    "$schema": "https://gist.githubusercontent.com/MrYurihi/4460e90099cf934b2078c7607bb0562b/raw/3713076d9d16ad66ba00aad3fa525872ab3438af/mod.json",
     "schemaVersion": 1,
     "id": "autoconfig1u",
     "version": "%VERSION%",


### PR DESCRIPTION
Fixes these warnings:
```
[22:00:44] [ForkJoinPool-1-worker-23/WARN]: The mod "autoconfig1u" contains invalid entries in its mod json:
- Unsupported root entry "$schema" at line 2 column 14
[22:00:44] [ForkJoinPool-1-worker-23/WARN]: "fabric.mod.json" from mod autoconfig1u did not have "schemaVersion" as first field.
```

Not sure what `"$schema"` is/was, but the URL is dead anyways.