### PR TITLE
Disable ugly and unnecessary Gson HTML escaping

### DIFF
--- a/src/main/java/me/sargunvohra/mcmods/autoconfig1u/serializer/GsonConfigSerializer.java
+++ b/src/main/java/me/sargunvohra/mcmods/autoconfig1u/serializer/GsonConfigSerializer.java
@@ -32,7 +32,7 @@ public class GsonConfigSerializer<T extends ConfigData> implements ConfigSeriali
     }
 
     public GsonConfigSerializer(Config definition, Class<T> configClass) {
-        this(definition, configClass, new GsonBuilder().setPrettyPrinting().create());
+        this(definition, configClass, new GsonBuilder().setPrettyPrinting().disableHtmlEscaping().create());
     }
 
     private Path getConfigPath() {


### PR DESCRIPTION
The characters `'`, `=`, `&`, `<` and `>` ([source](https://github.com/google/gson/blob/3958b1f78dc2b12da3ffd7426d3fc90550d46758/gson/src/main/java/com/google/gson/stream/JsonWriter.java#L158-L162)) are by default HTML-escaped, so they'll be serialized to something like `\u0027`.
This is absolutely not needed for locally stored config files (and shouldn't be needed even for web applications).

For example, a relatively readable string like
`%highlight{%msg%n}{FATAL=red, ERROR=red, WARN=normal, INFO=normal, DEBUG=normal, TRACE=normal}"`
turns into this monstrosity:
`%highlight{%msg%n}{FATAL\u003dred, ERROR\u003dred, WARN\u003dnormal, INFO\u003dnormal, DEBUG\u003dnormal, TRACE\u003dnormal}`

Luckily, the fix is extremely easy and has no downsides.
Configs containing such unicode sequences are still decoded correctly and they are even cleanly rewritten.

P.S. I believe I saw an issue about this in one of your projects, will look tomorrow if I can find it.
**edit** Couldn't find the issue, but going through Cloth Config I found that tweed can also disable HTML-escaping