### PR TITLE
Remove deprecated ModMenu API

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -29,5 +29,10 @@
     "mixins": [],
     "depends": {
         "fabricloader": ">=0.4.0"
+    },
+    "custom": {
+        "modmenu": {
+            "badges": [ "library" ]
+        }
     }
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -29,8 +29,5 @@
     "mixins": [],
     "depends": {
         "fabricloader": ">=0.4.0"
-    },
-    "custom": {
-        "modmenu:api": true
     }
 }


### PR DESCRIPTION
- Removes log warn
- Supports new API
- Properly fixes #30 